### PR TITLE
Allow expo to orient the screen automatically

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,6 @@
     "name": "kidvid",
     "slug": "kidvid",
     "version": "1.0.0",
-    "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "splash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@types/react": "~18.2.45",
         "expo": "~50.0.8",
+        "expo-screen-orientation": "~6.4.1",
         "expo-status-bar": "~1.11.1",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
@@ -7801,6 +7802,14 @@
       "integrity": "sha512-GTUb81vcPaF+5MtlBI1u9IjrZbGdF1ZUwz3u8Gc+rOLBblkZ7pYsj2mU/tu+k0khTckI9vcH4ZBksXWvE1ncjQ==",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-6.4.1.tgz",
+      "integrity": "sha512-VM0C9ORNL1aT6Dr2OUeryzV519n0FjtXI2m+HlijOMi1QT2bPg4tBkCd7HLgywU4dZ1Esa46ewUudmk+fOqmMQ==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-native": "0.73.4",
     "react-native-webview": "13.6.4",
     "react-native-youtube-iframe": "^2.3.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "expo-screen-orientation": "~6.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
This simple installs the expo screen orientation package and removes a line in the app.json file which hardcodes screen orientation to portrai.